### PR TITLE
Use proper Blockly version

### DIFF
--- a/src/BlocklyWorkspaceProps.ts
+++ b/src/BlocklyWorkspaceProps.ts
@@ -1,4 +1,5 @@
-import Blockly, { WorkspaceSvg } from "blockly";
+const Blockly = window.Blockly;
+const WorkspaceSvg = Blockly.WorkspaceSvg;
 import { RefObject } from "react";
 
 export interface CommonBlocklyProps {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import useBlocklyWorkspace from "./useBlocklyWorkspace";
 import BlocklyWorkspace from "./BlocklyWorkspace";
-import Blockly, {WorkspaceSvg, Workspace} from "blockly";
+const Blockly = window.Blockly;
+const WorkspaceSvg = Blockly.WorkspaceSvg;
+const Workspace = Blockly.Workspace;
 import ToolboxDefinition1 = Blockly.utils.toolbox.ToolboxDefinition;
 export type ToolboxDefinition = ToolboxDefinition1;
 export { BlocklyWorkspace, useBlocklyWorkspace };

--- a/src/useBlocklyWorkspace.ts
+++ b/src/useBlocklyWorkspace.ts
@@ -1,5 +1,6 @@
-import React from "react";
-import Blockly, { Workspace, WorkspaceSvg } from "blockly";
+const Blockly = window.Blockly;
+const WorkspaceSvg = Blockly.WorkspaceSvg;
+const Workspace = Blockly.Workspace;
 import { UseBlocklyProps } from "./BlocklyWorkspaceProps";
 
 import debounce from "./debounce";


### PR DESCRIPTION
react-blockly uses v10 of Blockly library but we need to use the window's Blockly version